### PR TITLE
add timeout to stack configuration

### DIFF
--- a/src/main/python/cfn_sphere/aws/cloudformation/cfn_api.py
+++ b/src/main/python/cfn_sphere/aws/cloudformation/cfn_api.py
@@ -75,7 +75,7 @@ class CloudFormation(object):
                                    parameters=stack.get_parameters_list(),
                                    capabilities=['CAPABILITY_IAM'])
 
-            self.wait_for_stack_action_to_complete(stack.name, "create")
+            self.wait_for_stack_action_to_complete(stack.name, "create", stack.timeout)
             self.logger.info("Create completed for {0}".format(stack.name))
         except BotoServerError as e:
             message = get_message_from_boto_server_error(e)
@@ -94,7 +94,7 @@ class CloudFormation(object):
                                    parameters=stack.get_parameters_list(),
                                    capabilities=['CAPABILITY_IAM'])
 
-            self.wait_for_stack_action_to_complete(stack.name, "update")
+            self.wait_for_stack_action_to_complete(stack.name, "update", stack.timeout)
             self.logger.info("Update completed for {0}".format(stack.name))
         except BotoServerError as e:
             message = get_message_from_boto_server_error(e)
@@ -145,7 +145,7 @@ class CloudFormation(object):
         raise CfnStackActionFailedException(
             "Timeout occurred waiting for events: '{0}' on stack {1}".format(expected_event, stack_name))
 
-    def wait_for_stack_action_to_complete(self, stack_name, action, timeout=600):
+    def wait_for_stack_action_to_complete(self, stack_name, action, timeout):
 
         allowed_actions = ["create", "update", "delete"]
         assert action.lower() in allowed_actions, "action argument must be one of {0}".format(allowed_actions)

--- a/src/main/python/cfn_sphere/aws/cloudformation/stack.py
+++ b/src/main/python/cfn_sphere/aws/cloudformation/stack.py
@@ -1,11 +1,12 @@
 
 
 class CloudFormationStack(object):
-    def __init__(self, template, parameters, name, region):
+    def __init__(self, template, parameters, name, region, timeout=600):
         self.template = template
         self.parameters = parameters
         self.name = name
         self.region = region
+        self.timeout = timeout
 
     def get_parameters_list(self):
         return [(key, value) for key, value in self.parameters.items()]

--- a/src/main/python/cfn_sphere/config.py
+++ b/src/main/python/cfn_sphere/config.py
@@ -56,6 +56,7 @@ class Config(object):
 class StackConfig(object):
     def __init__(self, stack_config_dict, working_dir=None):
         self.parameters = stack_config_dict.get('parameters', {})
+        self.timeout = stack_config_dict.get('timeout', 600)
         self.working_dir = working_dir
 
         try:

--- a/src/main/python/cfn_sphere/main.py
+++ b/src/main/python/cfn_sphere/main.py
@@ -35,7 +35,7 @@ class StackActionHandler(object):
 
             parameters = self.parameter_resolver.resolve_parameter_values(stack_config.parameters, stack_name)
 
-            stack = CloudFormationStack(template, parameters, stack_name, self.region)
+            stack = CloudFormationStack(template, parameters, stack_name, self.region, stack_config.timeout)
 
             if stack_name in existing_stacks:
 

--- a/src/unittest/python/cloudformation_api_tests.py
+++ b/src/unittest/python/cloudformation_api_tests.py
@@ -116,6 +116,7 @@ class CloudFormationApiTests(unittest2.TestCase):
         stack.template = Mock(spec=CloudFormationTemplate)
         stack.template.name = "template-name"
         stack.template.get_template_json.return_value = {'key': 'value'}
+        stack.timeout = 42
 
         cfn = CloudFormation()
         cfn.create_stack(stack)
@@ -135,6 +136,7 @@ class CloudFormationApiTests(unittest2.TestCase):
         stack.template = Mock(spec=CloudFormationTemplate)
         stack.template.name = "template-name"
         stack.template.get_template_json.return_value = {'key': 'value'}
+        stack.timeout = 42
 
         cfn = CloudFormation()
         cfn.update_stack(stack)


### PR DESCRIPTION
5 minutes default timeout for CloudFormation create or update are not enough for our application stack. Introduced per stack configuration option, with the default still being 5 minutes