### PR TITLE
Add --tags options, support running on python 3.9+ and testing on python 3.10+

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Cfn-Sphere supports native cloudformation templates written in JSON or YAML, loc
 
 Requirements:
 
-* python >= 2.6
+* python >= 3.5
 * virtualenv
 * pybuilder
 
@@ -97,7 +97,7 @@ Execute:
 
     git clone https://github.com/cfn-sphere/cfn-sphere.git
     cd cfn-sphere
-    virtualenv .venv --python=python2.7
+    virtualenv .venv --python=python3.10
     source .venv/bin/activate
     pip install pybuilder
     pyb install_dependencies

--- a/build.py
+++ b/build.py
@@ -26,7 +26,6 @@ default_task = ['clean', 'analyze', 'package']
 
 @init
 def set_properties(project):
-    project.build_depends_on("unittest2")
     project.build_depends_on("mock")
     project.build_depends_on("moto")
     project.depends_on('six')

--- a/build.py
+++ b/build.py
@@ -19,7 +19,7 @@ description = "cfn-sphere - A CLI tool intended to simplify AWS CloudFormation h
 license = 'APACHE LICENSE, VERSION 2.0'
 summary = 'cfn-sphere AWS CloudFormation management cli'
 url = 'https://github.com/cfn-sphere/cfn-sphere'
-version = '1.0.6'
+version = '1.1.0'
 
 default_task = ['clean', 'analyze', 'package']
 

--- a/src/integrationtest/python/aws_kms_tests.py
+++ b/src/integrationtest/python/aws_kms_tests.py
@@ -1,13 +1,13 @@
 # -*- coding: utf-8 -*-
 
 import boto3
-import unittest2
+import unittest
 
 from cfn_sphere.aws.kms import KMS
 from cfn_sphere.exceptions import CfnSphereBotoError
 
 
-class KMSTests(unittest2.TestCase):
+class KMSTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         # Create a KMS key, unless it already exists. Simple create&delete is
@@ -50,4 +50,4 @@ class KMSTests(unittest2.TestCase):
 
 
 if __name__ == "__main__":
-    unittest2.main()
+    unittest.main()

--- a/src/main/python/cfn_sphere/__init__.py
+++ b/src/main/python/cfn_sphere/__init__.py
@@ -16,6 +16,7 @@ class StackActionHandler(object):
         self.cfn = CloudFormation(region=self.config.region)
         self.parameter_resolver = ParameterResolver(region=self.config.region)
         self.cli_parameters = config.cli_params
+        self.cli_tags = config.cli_tags
 
     def create_or_update_stacks(self):
         desired_stacks = self.config.stacks
@@ -37,9 +38,13 @@ class StackActionHandler(object):
             template = TemplateHandler.get_template(stack_config.template_url, stack_config.working_dir)
             parameters = self.parameter_resolver.resolve_parameter_values(stack_name, stack_config, self.cli_parameters)
 
+            full_tags = {}
+            full_tags.update(stack_config.tags)
+            full_tags.update(self.config.cli_tags)
+
             stack = CloudFormationStack(template=template,
                                         parameters=parameters,
-                                        tags=stack_config.tags,
+                                        tags=full_tags,
                                         name=stack_name,
                                         region=self.config.region,
                                         timeout=stack_config.timeout,

--- a/src/main/python/cfn_sphere/cli.py
+++ b/src/main/python/cfn_sphere/cli.py
@@ -67,7 +67,8 @@ def cli(name=None):
               help="Override user confirm dialog with yes")
 @click.option('--yes', '-y', is_flag=True, default=False, envvar='CFN_SPHERE_CONFIRM',
               help="Override user confirm dialog with yes (alias for -c/--confirm")
-def sync(config, parameter, suffix, debug, confirm, yes):
+@click.option('--tags', default=None, envvar='CFN_SPHERE_STACK_TAGS', type=click.STRING)
+def sync(config, parameter, suffix, debug, confirm, yes, tags):
     confirm = confirm or yes
     if debug:
         LOGGER.setLevel(logging.DEBUG)
@@ -85,8 +86,7 @@ def sync(config, parameter, suffix, debug, confirm, yes):
             get_first_account_alias_or_account_id()), abort=True)
 
     try:
-
-        config = Config(config_file=config, cli_params=parameter, stack_name_suffix=suffix)
+        config = Config(config_file=config, cli_params=parameter, cli_tags=tags, stack_name_suffix=suffix)
         StackActionHandler(config).create_or_update_stacks()
     except CfnSphereException as e:
         LOGGER.error(e)

--- a/src/main/python/cfn_sphere/file_loader.py
+++ b/src/main/python/cfn_sphere/file_loader.py
@@ -78,9 +78,9 @@ class FileLoader(object):
 
         try:
             if url.lower().endswith(".json"):
-                return json.loads(file_content, encoding='utf-8')
+                return json.loads(file_content)
             elif url.lower().endswith(".template"):
-                return json.loads(file_content, encoding='utf-8')
+                return json.loads(file_content)
             elif url.lower().endswith(".yml") or url.lower().endswith(".yaml"):
                 if hasattr(yaml, 'FullLoader'):
                     loader = yaml.FullLoader

--- a/src/main/python/cfn_sphere/util.py
+++ b/src/main/python/cfn_sphere/util.py
@@ -118,7 +118,7 @@ def convert_json_to_yaml_string(data):
 def convert_yaml_to_json_string(data):
     if not data:
         return '{}'
-    return json.dumps(yaml.load(data), indent=2)
+    return json.dumps(yaml.load(data, yaml.SafeLoader), indent=2)
 
 
 def convert_dict_to_json_string(data):

--- a/src/unittest/python/aws_tests/cfn_tests.py
+++ b/src/unittest/python/aws_tests/cfn_tests.py
@@ -1,5 +1,5 @@
 try:
-    from unittest2 import TestCase
+    from unittest import TestCase
     from mock import Mock, patch
 except ImportError:
     from unittest import TestCase

--- a/src/unittest/python/aws_tests/ec2_tests.py
+++ b/src/unittest/python/aws_tests/ec2_tests.py
@@ -1,5 +1,5 @@
 try:
-    from unittest2 import TestCase
+    from unittest import TestCase
     from mock import Mock, patch
 except ImportError:
     from unittest import TestCase

--- a/src/unittest/python/aws_tests/kms_tests.py
+++ b/src/unittest/python/aws_tests/kms_tests.py
@@ -1,5 +1,5 @@
 try:
-    from unittest2 import TestCase
+    from unittest import TestCase
     from mock import patch
 except ImportError:
     from unittest import TestCase

--- a/src/unittest/python/aws_tests/s3_tests.py
+++ b/src/unittest/python/aws_tests/s3_tests.py
@@ -1,9 +1,9 @@
 from botocore.response import StreamingBody
-import unittest2
+import unittest
 
 
 try:
-    from unittest2 import TestCase
+    from unittest import TestCase
     from mock import Mock, patch
 except ImportError:
     from unittest import TestCase
@@ -12,7 +12,7 @@ except ImportError:
 from cfn_sphere.aws.s3 import S3
 
 
-class S3Tests(unittest2.TestCase):
+class S3Tests(unittest.TestCase):
     def test_parse_url_properly_parses_s3_url(self):
         (protocol, bucket_name, key_name) = S3._parse_url('s3://my-bucket/my/key/file.json')
         self.assertEqual('s3', protocol)

--- a/src/unittest/python/aws_tests/ssm_tests.py
+++ b/src/unittest/python/aws_tests/ssm_tests.py
@@ -1,5 +1,5 @@
 try:
-    from unittest2 import TestCase
+    from unittest import TestCase
     from mock import patch
 except ImportError:
     from unittest import TestCase

--- a/src/unittest/python/cli_tests.py
+++ b/src/unittest/python/cli_tests.py
@@ -2,7 +2,7 @@ from cfn_sphere.cli import get_first_account_alias_or_account_id
 from cfn_sphere.exceptions import CfnSphereException
 
 try:
-    from unittest2 import TestCase
+    from unittest import TestCase
     from mock import patch, Mock
 except ImportError:
     from unittest import TestCase

--- a/src/unittest/python/cloudformation_template_tests.py
+++ b/src/unittest/python/cloudformation_template_tests.py
@@ -1,5 +1,5 @@
 try:
-    from unittest2 import TestCase
+    from unittest import TestCase
 except ImportError:
     from unittest import TestCase
 

--- a/src/unittest/python/file_generator_tests.py
+++ b/src/unittest/python/file_generator_tests.py
@@ -1,4 +1,4 @@
-from unittest2 import TestCase
+from unittest import TestCase
 
 from cfn_sphere.exceptions import CfnSphereException
 from cfn_sphere.file_generator import FileGenerator

--- a/src/unittest/python/file_loader_tests.py
+++ b/src/unittest/python/file_loader_tests.py
@@ -69,7 +69,7 @@ class FileLoaderTests(TestCase):
         get_file_mock.return_value = get_file_return_value
 
         FileLoader.get_yaml_or_json_file('foo.json', 'baa')
-        json_mock.loads.assert_called_once_with(get_file_return_value, encoding="utf-8")
+        json_mock.loads.assert_called_once_with(get_file_return_value)
 
     @patch("cfn_sphere.file_loader.yaml")
     @patch("cfn_sphere.file_loader.FileLoader.get_file")

--- a/src/unittest/python/file_loader_tests.py
+++ b/src/unittest/python/file_loader_tests.py
@@ -1,7 +1,7 @@
 import yaml
 
 try:
-    from unittest2 import TestCase
+    from unittest import TestCase
     from mock import patch, Mock
 except ImportError:
     from unittest import TestCase

--- a/src/unittest/python/stack_action_handler_tests.py
+++ b/src/unittest/python/stack_action_handler_tests.py
@@ -1,5 +1,5 @@
 try:
-    from unittest2 import TestCase
+    from unittest import TestCase
     from mock import patch, Mock, call
 except ImportError:
     from unittest import TestCase

--- a/src/unittest/python/stack_configuration_tests/config_tests.py
+++ b/src/unittest/python/stack_configuration_tests/config_tests.py
@@ -1,7 +1,7 @@
 import os
 
 try:
-    from unittest2 import TestCase
+    from unittest import TestCase
 except ImportError:
     from unittest import TestCase
 

--- a/src/unittest/python/stack_configuration_tests/dependency_resolver_tests.py
+++ b/src/unittest/python/stack_configuration_tests/dependency_resolver_tests.py
@@ -1,5 +1,5 @@
 try:
-    from unittest2 import TestCase
+    from unittest import TestCase
 except ImportError:
     from unittest import TestCase
 

--- a/src/unittest/python/stack_configuration_tests/parameter_resolver_tests.py
+++ b/src/unittest/python/stack_configuration_tests/parameter_resolver_tests.py
@@ -1,5 +1,5 @@
 try:
-    from unittest2 import TestCase
+    from unittest import TestCase
     from mock import patch, Mock
 except ImportError:
     from unittest import TestCase

--- a/src/unittest/python/template/template_handler_tests.py
+++ b/src/unittest/python/template/template_handler_tests.py
@@ -4,7 +4,7 @@ from cfn_sphere import TemplateHandler
 from cfn_sphere.template import CloudFormationTemplate
 
 try:
-    from unittest2 import TestCase
+    from unittest import TestCase
     from mock import Mock
 except ImportError:
     from unittest import TestCase

--- a/src/unittest/python/template/template_tests.py
+++ b/src/unittest/python/template/template_tests.py
@@ -5,7 +5,7 @@ from six import string_types
 from cfn_sphere.template import CloudFormationTemplate
 
 try:
-    from unittest2 import TestCase
+    from unittest import TestCase
     from mock import Mock
 except ImportError:
     from unittest import TestCase

--- a/src/unittest/python/template/transformer_tests.py
+++ b/src/unittest/python/template/transformer_tests.py
@@ -1,7 +1,7 @@
 import json
 
 try:
-    from unittest2 import TestCase
+    from unittest import TestCase
     from mock import Mock
 except ImportError:
     from unittest import TestCase

--- a/src/unittest/python/util_tests.py
+++ b/src/unittest/python/util_tests.py
@@ -27,6 +27,7 @@ class UtilTests(TestCase):
           foo: baa
         """)
 
+        print(util.convert_yaml_to_json_string(data))
         self.assertEqual('{\n  "foo": {\n    "foo": "baa"\n  }\n}', util.convert_yaml_to_json_string(data))
 
     def test_convert_yaml_to_json_string_returns_valid_json_string_on_empty_string_input(self):

--- a/src/unittest/python/util_tests.py
+++ b/src/unittest/python/util_tests.py
@@ -3,7 +3,7 @@ import tempfile
 from git import InvalidGitRepositoryError
 
 try:
-    from unittest2 import TestCase
+    from unittest import TestCase
     from mock import patch, Mock
 except ImportError:
     from unittest import TestCase

--- a/src/unittest/python/util_tests.py
+++ b/src/unittest/python/util_tests.py
@@ -27,7 +27,6 @@ class UtilTests(TestCase):
           foo: baa
         """)
 
-        print(util.convert_yaml_to_json_string(data))
         self.assertEqual('{\n  "foo": {\n    "foo": "baa"\n  }\n}', util.convert_yaml_to_json_string(data))
 
     def test_convert_yaml_to_json_string_returns_valid_json_string_on_empty_string_input(self):


### PR DESCRIPTION
Full disclosure, I am not a CFN developer or user and my python is a quite rusty.

I'm not sure if this repository still sees any maintenance or not, but it would be great if you could take a look at this commit to review and possibly release.

This commit adds a `--tags "k1=v1 k2=v2"` option to the sync command.  This is needed for us to do some automatic tagging of resource with values only known at the moment that `cf sync ...` is run.  This format was chosen because it's easy to parse and it matches the arguments that you would need to pass to the `aws cloudformation deploy --tags` command, though that command allows each kv pairing to be it's own argv entry, where this patch requires wrapping all of them as a single string.

I don't really know how to write the relevant tests here, but some guidance would help get them written.