### PR TITLE
feat(AP-3262): derive tags from repository identity

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,22 @@
+name: "CodeQL"
+
+on:
+  # workflow_dispatch enables manual triggering of the workflow
+  workflow_dispatch:
+  schedule:
+  - cron: '8 23 * * 3'
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    steps:
+    - name: S24 static application security testing (SAST) action
+      uses: scout24/s24-sast-action@v1
+      with:
+        languages: python
+

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Cfn-Sphere supports native cloudformation templates written in JSON or YAML, loc
 
 Requirements:
 
-* python >= 2.6
+* python >= 2.6, <=3.9 -- unittest2 cannot run on python3.10 due to the collections.MutableMapping -> collections.abc.MutableMapping rename
 * virtualenv
 * pybuilder
 
@@ -97,7 +97,7 @@ Execute:
 
     git clone https://github.com/cfn-sphere/cfn-sphere.git
     cd cfn-sphere
-    virtualenv .venv --python=python2.7
+    virtualenv .venv --python=python3.9
     source .venv/bin/activate
     pip install pybuilder
     pyb install_dependencies

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Cfn-Sphere supports native cloudformation templates written in JSON or YAML, loc
 
 Requirements:
 
-* python >= 2.6, <=3.9 -- unittest2 cannot run on python3.10 due to the collections.MutableMapping -> collections.abc.MutableMapping rename
+* python >= 3.6
 * virtualenv
 * pybuilder
 
@@ -97,7 +97,7 @@ Execute:
 
     git clone https://github.com/cfn-sphere/cfn-sphere.git
     cd cfn-sphere
-    virtualenv .venv --python=python3.9
+    virtualenv .venv --python=python3.10
     source .venv/bin/activate
     pip install pybuilder
     pyb install_dependencies

--- a/README.md
+++ b/README.md
@@ -102,6 +102,17 @@ Execute:
     pip install pybuilder
     pyb install_dependencies
     pyb
+    
+To put on FASt artifactory: 
+    
+    pip install twine
+    python setup.py sdist
+    twine upload --repository-url https://fast.cloud.scout24.com/artifactory/api/pypi/pypi-local -p $FAST_TOKEN -u $FAST_USER dist/*
+    
+To check if you can install from FASt:
+
+    pip search s24-cfn-sphere --index https://${FAST_USER}:${FAST_TOKEN}@fast.cloud.scout24.com/artifactory/api/pypi/pypi-local/
+    pip install --index-url=https://${FAST_USER}:${FAST_TOKEN}@fast.cloud.scout24.com/artifactory/api/pypi/pypi-local/simple --upgrade s24-cfn-sphere
 
 ## Contribution
 

--- a/build.py
+++ b/build.py
@@ -26,7 +26,6 @@ default_task = ['clean', 'analyze', 'package']
 
 @init
 def set_properties(project):
-    project.build_depends_on("unittest2")
     project.build_depends_on("mock")
     project.build_depends_on("moto")
     project.depends_on('six')

--- a/build.py
+++ b/build.py
@@ -19,7 +19,7 @@ description = "cfn-sphere - A CLI tool intended to simplify AWS CloudFormation h
 license = 'APACHE LICENSE, VERSION 2.0'
 summary = 'cfn-sphere AWS CloudFormation management cli'
 url = 'https://github.com/cfn-sphere/cfn-sphere'
-version = '1.0.6'
+version = '1.1.1'
 
 default_task = ['clean', 'analyze', 'package']
 

--- a/build.py
+++ b/build.py
@@ -19,7 +19,7 @@ description = "cfn-sphere - A CLI tool intended to simplify AWS CloudFormation h
 license = 'APACHE LICENSE, VERSION 2.0'
 summary = 'cfn-sphere AWS CloudFormation management cli'
 url = 'https://github.com/cfn-sphere/cfn-sphere'
-version = '1.1.1'
+version = '1.1.2'
 
 default_task = ['clean', 'analyze', 'package']
 

--- a/build.py
+++ b/build.py
@@ -19,7 +19,7 @@ description = "cfn-sphere - A CLI tool intended to simplify AWS CloudFormation h
 license = 'APACHE LICENSE, VERSION 2.0'
 summary = 'cfn-sphere AWS CloudFormation management cli'
 url = 'https://github.com/cfn-sphere/cfn-sphere'
-version = '1.1.2'
+version = '1.1.3'
 
 default_task = ['clean', 'analyze', 'package']
 

--- a/build.py
+++ b/build.py
@@ -12,7 +12,7 @@ use_plugin("python.distutils")
 use_plugin('copy_resources')
 use_plugin('filter_resources')
 
-name = "cfn-sphere"
+name = "s24-cfn-sphere"
 
 authors = [Author('Marco Hoyer', 'marco_hoyer@gmx.de')]
 description = "cfn-sphere - A CLI tool intended to simplify AWS CloudFormation handling."

--- a/build.py
+++ b/build.py
@@ -19,7 +19,7 @@ description = "cfn-sphere - A CLI tool intended to simplify AWS CloudFormation h
 license = 'APACHE LICENSE, VERSION 2.0'
 summary = 'cfn-sphere AWS CloudFormation management cli'
 url = 'https://github.com/cfn-sphere/cfn-sphere'
-version = '1.1.3'
+version = '1.1.4'
 
 default_task = ['clean', 'analyze', 'package']
 

--- a/src/integrationtest/python/aws_kms_tests.py
+++ b/src/integrationtest/python/aws_kms_tests.py
@@ -1,13 +1,13 @@
 # -*- coding: utf-8 -*-
 
 import boto3
-import unittest2
+import unittest
 
 from cfn_sphere.aws.kms import KMS
 from cfn_sphere.exceptions import CfnSphereBotoError
 
 
-class KMSTests(unittest2.TestCase):
+class KMSTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         # Create a KMS key, unless it already exists. Simple create&delete is
@@ -50,4 +50,4 @@ class KMSTests(unittest2.TestCase):
 
 
 if __name__ == "__main__":
-    unittest2.main()
+    unittest.main()

--- a/src/main/python/cfn_sphere/aws/cfn.py
+++ b/src/main/python/cfn_sphere/aws/cfn.py
@@ -280,7 +280,8 @@ class CloudFormation(object):
             "Parameters": stack.get_parameters_list(),
             "Capabilities": [
                 'CAPABILITY_IAM',
-                'CAPABILITY_NAMED_IAM'
+                'CAPABILITY_NAMED_IAM',
+                'CAPABILITY_AUTO_EXPAND'
             ],
             "Tags": stack.get_tags_list()
         }
@@ -310,7 +311,8 @@ class CloudFormation(object):
             "Parameters": stack.get_parameters_list(),
             "Capabilities": [
                 'CAPABILITY_IAM',
-                'CAPABILITY_NAMED_IAM'
+                'CAPABILITY_NAMED_IAM',
+                'CAPABILITY_AUTO_EXPAND'
             ],
             "Tags": stack.get_tags_list()
         }

--- a/src/main/python/cfn_sphere/cli.py
+++ b/src/main/python/cfn_sphere/cli.py
@@ -41,6 +41,8 @@ def get_first_account_alias_or_account_id():
 
 
 def check_update_available():
+    # Disable update checking completely, but in a way that will cause fewest merge conflicts
+    return
     latest_version = get_latest_version()
     if latest_version and __version__ != latest_version:
         click.confirm(

--- a/src/main/python/cfn_sphere/cli.py
+++ b/src/main/python/cfn_sphere/cli.py
@@ -89,35 +89,6 @@ def sync(config, parameter, suffix, debug, confirm, yes, tags):
 
     try:
         config = Config(config_file=config, cli_params=parameter, cli_tags=tags, stack_name_suffix=suffix)
-        
-        # Check metadata.yaml exists
-        if config.stack_config_base_dir:
-                    metadata_file = config._find_metadata_file(config.stack_config_base_dir)
-                    if not metadata_file:
-                        LOGGER.warning("metadata.yaml file is missing for stack deployment")
-       
-        # Check tags exist
-        REQUIRED_TAGS = ['component-id', 'confidentiality', 'criticality', 'stage']
-        for required_tag in REQUIRED_TAGS:
-            if required_tag not in config.default_tags:
-                if required_tag == 'component-id':
-                    LOGGER.warning(
-                        "Required tag 'component-id' is missing. "
-                        "Please ensure 'id' and 'orgId' fields exist in metadata.yaml. "
-                        "Example:\n  id: my-service-name\n  orgId: Scout24"
-                    )
-                else:
-                    LOGGER.warning(f"Required tag '{required_tag}' is missing")
-
-        # Confidentiality tag value validation
-        ALLOWED_CONFIDENTIALITY = ['public', 'company-internal', 'company-internal-standard-pii', 'company-confidential', 'company-confidential-sensitive-pii']
-        if 'confidentiality' in config.default_tags:
-            confidentiality_value = config.default_tags['confidentiality']
-            if confidentiality_value not in ALLOWED_CONFIDENTIALITY:
-                LOGGER.warning(
-                    f"Invalid confidentiality value: '{confidentiality_value}'. "
-                    f"Must be one of: {', '.join(ALLOWED_CONFIDENTIALITY)}"
-                )
 
         # Stage tag value validation
         ALLOWED_STAGES = ['dev', 'pro', 'box', 'tuv']
@@ -127,17 +98,6 @@ def sync(config, parameter, suffix, debug, confirm, yes, tags):
                 LOGGER.warning(
                     f"Invalid stage value: '{stage_value}'. "
                     f"Must be one of: {', '.join(ALLOWED_STAGES)}"
-                )
-       
-        # Criticality tag value validation
-        ALLOWED_CRITICALITY = ['platinum', 'gold', 'silver', 'bronze', 'notinuse']
-
-        if 'criticality' in config.default_tags:
-            criticality_value = config.default_tags['criticality']
-            if criticality_value not in ALLOWED_CRITICALITY:
-                LOGGER.warning(
-                    f"Invalid criticality value: '{criticality_value}'. "
-                    f"Must be one of: {', '.join(ALLOWED_CRITICALITY)}"
                 )
 
         StackActionHandler(config).create_or_update_stacks()

--- a/src/main/python/cfn_sphere/cli.py
+++ b/src/main/python/cfn_sphere/cli.py
@@ -89,6 +89,43 @@ def sync(config, parameter, suffix, debug, confirm, yes, tags):
 
     try:
         config = Config(config_file=config, cli_params=parameter, cli_tags=tags, stack_name_suffix=suffix)
+        
+        REQUIRED_TAGS = ['confidentiality', 'criticality', 'stage']
+        for required_tag in REQUIRED_TAGS:
+            if required_tag not in config.default_tags:
+                LOGGER.warning(f"Required tag '{required_tag}' is missing")
+
+
+        ALLOWED_CONFIDENTIALITY = ['public', 'company-internal', 'company-internal-standard-pii', 'company-confidential', 'company-confidential-sensitive-pii', 'notinuse']
+        
+        if 'confidentiality' in config.default_tags:
+            confidentiality_value = config.default_tags['confidentiality']
+            if confidentiality_value not in ALLOWED_CONFIDENTIALITY:
+                raise CfnSphereException(
+                    f"Invalid confidentiality value: '{confidentiality_value}'. "
+                    f"Must be one of: {', '.join(ALLOWED_CONFIDENTIALITY)}"
+                )
+        
+        ALLOWED_STAGES = ['dev', 'pro', 'box']
+
+        if 'stage' in config.default_tags:
+            stage_value = config.default_tags['stage']
+            if stage_value not in ALLOWED_STAGES:
+                LOGGER.warning(
+                    f"Invalid stage value: '{stage_value}'. "
+                    f"Must be one of: {', '.join(ALLOWED_STAGES)}"
+                )
+
+        ALLOWED_CRITICALITY = ['platinum', 'gold', 'silver', 'bronze', 'notinuse']
+
+        if 'criticality' in config.default_tags:
+            criticality_value = config.default_tags['criticality']
+            if criticality_value not in ALLOWED_CRITICALITY:
+                raise CfnSphereException(
+                    f"Invalid criticality value: '{criticality_value}'. "
+                    f"Must be one of: {', '.join(ALLOWED_CRITICALITY)}"
+                )
+
         StackActionHandler(config).create_or_update_stacks()
     except CfnSphereException as e:
         LOGGER.error(e)

--- a/src/main/python/cfn_sphere/cli.py
+++ b/src/main/python/cfn_sphere/cli.py
@@ -91,7 +91,7 @@ def sync(config, parameter, suffix, debug, confirm, yes, tags):
         config = Config(config_file=config, cli_params=parameter, cli_tags=tags, stack_name_suffix=suffix)
 
         # Stage tag value validation
-        ALLOWED_STAGES = ['dev', 'pro', 'box', 'tuv']
+        ALLOWED_STAGES = ['dev', 'pro', 'box', 'stg', 'loc', 'glo']
         if 'stage' in config.default_tags:
             stage_value = config.default_tags['stage']
             if stage_value not in ALLOWED_STAGES:

--- a/src/main/python/cfn_sphere/cli.py
+++ b/src/main/python/cfn_sphere/cli.py
@@ -120,7 +120,7 @@ def sync(config, parameter, suffix, debug, confirm, yes, tags):
                 )
 
         # Stage tag value validation
-        ALLOWED_STAGES = ['dev', 'pro', 'box']
+        ALLOWED_STAGES = ['dev', 'pro', 'box', 'tuv']
         if 'stage' in config.default_tags:
             stage_value = config.default_tags['stage']
             if stage_value not in ALLOWED_STAGES:

--- a/src/main/python/cfn_sphere/cli.py
+++ b/src/main/python/cfn_sphere/cli.py
@@ -90,29 +90,38 @@ def sync(config, parameter, suffix, debug, confirm, yes, tags):
     try:
         config = Config(config_file=config, cli_params=parameter, cli_tags=tags, stack_name_suffix=suffix)
         
+        # Check metadata.yaml exists
         if config.stack_config_base_dir:
                     metadata_file = config._find_metadata_file(config.stack_config_base_dir)
                     if not metadata_file:
                         LOGGER.warning("metadata.yaml file is missing for stack deployment")
-
-        REQUIRED_TAGS = ['confidentiality', 'criticality', 'stage', 'id']
+       
+        # Check tags exist
+        REQUIRED_TAGS = ['component-id', 'confidentiality', 'criticality', 'stage']
         for required_tag in REQUIRED_TAGS:
             if required_tag not in config.default_tags:
-                LOGGER.warning(f"Required tag '{required_tag}' is missing")
+                # Better error message for metadata.yaml fields
+                if required_tag == 'component-id':
+                    LOGGER.warning(
+                        "Required tag 'component-id' is missing. "
+                        "Please ensure 'id' and 'orgId' fields exist in metadata.yaml. "
+                        "Example:\n  id: my-service-name\n  orgId: Scout24"
+                    )
+                else:
+                    LOGGER.warning(f"Required tag '{required_tag}' is missing")
 
-
-        ALLOWED_CONFIDENTIALITY = ['public', 'company-internal', 'company-internal-standard-pii', 'company-confidential', 'company-confidential-sensitive-pii', 'notinuse']
-        
+        # Confidentiality tag value validation
+        ALLOWED_CONFIDENTIALITY = ['public', 'company-internal', 'company-internal-standard-pii', 'company-confidential', 'company-confidential-sensitive-pii']
         if 'confidentiality' in config.default_tags:
             confidentiality_value = config.default_tags['confidentiality']
             if confidentiality_value not in ALLOWED_CONFIDENTIALITY:
-                raise CfnSphereException(
+                LOGGER.warning(
                     f"Invalid confidentiality value: '{confidentiality_value}'. "
                     f"Must be one of: {', '.join(ALLOWED_CONFIDENTIALITY)}"
                 )
-        
-        ALLOWED_STAGES = ['dev', 'pro', 'box']
 
+        # Stage tag value validation
+        ALLOWED_STAGES = ['dev', 'pro', 'box']
         if 'stage' in config.default_tags:
             stage_value = config.default_tags['stage']
             if stage_value not in ALLOWED_STAGES:
@@ -120,13 +129,14 @@ def sync(config, parameter, suffix, debug, confirm, yes, tags):
                     f"Invalid stage value: '{stage_value}'. "
                     f"Must be one of: {', '.join(ALLOWED_STAGES)}"
                 )
-
+       
+        # Criticality tag value validation
         ALLOWED_CRITICALITY = ['platinum', 'gold', 'silver', 'bronze', 'notinuse']
 
         if 'criticality' in config.default_tags:
             criticality_value = config.default_tags['criticality']
             if criticality_value not in ALLOWED_CRITICALITY:
-                raise CfnSphereException(
+                LOGGER.warning(
                     f"Invalid criticality value: '{criticality_value}'. "
                     f"Must be one of: {', '.join(ALLOWED_CRITICALITY)}"
                 )

--- a/src/main/python/cfn_sphere/cli.py
+++ b/src/main/python/cfn_sphere/cli.py
@@ -100,7 +100,6 @@ def sync(config, parameter, suffix, debug, confirm, yes, tags):
         REQUIRED_TAGS = ['component-id', 'confidentiality', 'criticality', 'stage']
         for required_tag in REQUIRED_TAGS:
             if required_tag not in config.default_tags:
-                # Better error message for metadata.yaml fields
                 if required_tag == 'component-id':
                     LOGGER.warning(
                         "Required tag 'component-id' is missing. "

--- a/src/main/python/cfn_sphere/cli.py
+++ b/src/main/python/cfn_sphere/cli.py
@@ -90,7 +90,12 @@ def sync(config, parameter, suffix, debug, confirm, yes, tags):
     try:
         config = Config(config_file=config, cli_params=parameter, cli_tags=tags, stack_name_suffix=suffix)
         
-        REQUIRED_TAGS = ['confidentiality', 'criticality', 'stage']
+        if config.stack_config_base_dir:
+                    metadata_file = config._find_metadata_file(config.stack_config_base_dir)
+                    if not metadata_file:
+                        LOGGER.warning("metadata.yaml file is missing for stack deployment")
+
+        REQUIRED_TAGS = ['confidentiality', 'criticality', 'stage', 'id']
         for required_tag in REQUIRED_TAGS:
             if required_tag not in config.default_tags:
                 LOGGER.warning(f"Required tag '{required_tag}' is missing")

--- a/src/main/python/cfn_sphere/file_loader.py
+++ b/src/main/python/cfn_sphere/file_loader.py
@@ -78,9 +78,9 @@ class FileLoader(object):
 
         try:
             if url.lower().endswith(".json"):
-                return json.loads(file_content, encoding='utf-8')
+                return json.loads(file_content)
             elif url.lower().endswith(".template"):
-                return json.loads(file_content, encoding='utf-8')
+                return json.loads(file_content)
             elif url.lower().endswith(".yml") or url.lower().endswith(".yaml"):
                 if hasattr(yaml, 'FullLoader'):
                     loader = yaml.FullLoader

--- a/src/main/python/cfn_sphere/stack_configuration/__init__.py
+++ b/src/main/python/cfn_sphere/stack_configuration/__init__.py
@@ -35,8 +35,9 @@ class Config(object):
         self.stack_name_suffix = stack_name_suffix
 
         metadata_file = self._find_metadata_file(self.stack_config_base_dir)
+        metadata_tags = {}
         if metadata_file:
-            metadata_tags = self._read_metadata_tags(metadata_file)
+            metadata_tags.update(self._read_metadata_tags(metadata_file))
 
         stage = self._find_stage_tag()
         if stage:
@@ -147,6 +148,9 @@ class Config(object):
 
     def _find_metadata_file(self, basedir):
         f = None
+
+        if not basedir:
+            basedir = os.getcwd()
 
         _, cur = os.path.splitdrive(basedir)
         # We have an extra limit of 1000 possible directory depth.  This is high

--- a/src/main/python/cfn_sphere/stack_configuration/__init__.py
+++ b/src/main/python/cfn_sphere/stack_configuration/__init__.py
@@ -149,7 +149,10 @@ class Config(object):
         f = None
 
         _, cur = os.path.splitdrive(basedir)
-
+        # We have an extra limit of 1000 possible directory depth.  This is high
+        # enough that it's unlikely to be hit in reality but creates a sufficient
+        # upper bounds to the number of invocations so as not to deadlock the
+        # program
         for i in range(1000):
             possibility = os.path.join(cur, "metadata.yaml")
             if os.path.isfile(possibility):

--- a/src/main/python/cfn_sphere/stack_configuration/__init__.py
+++ b/src/main/python/cfn_sphere/stack_configuration/__init__.py
@@ -50,7 +50,7 @@ class Config(object):
         self.default_tags.update(metadata_tags)
         self.default_tags.update(self.cli_tags)
 
-        self.default_tags["cfn_sphere"] = "yes"
+        self.default_tags["iac-tool"] = "cfn-sphere"
 
         self.default_failure_action = config_dict.get("on_failure", "ROLLBACK")
         self.default_disable_rollback = config_dict.get("disable_rollback", False)

--- a/src/main/python/cfn_sphere/stack_configuration/__init__.py
+++ b/src/main/python/cfn_sphere/stack_configuration/__init__.py
@@ -143,11 +143,9 @@ class Config(object):
             self.logger.info("Determined service-id to be %s" % service_id)
             self.logger.info("Determined component-id to be %s" % component_id)
         
-        # Read confidentiality regardless of id
         if metadata.get('confidentiality'):
             tags['confidentiality'] = metadata['confidentiality']
         
-        # Read criticality regardless of id
         criticality_value = metadata.get('criticality', {}).get('value')
         if criticality_value:
             tags['criticality'] = criticality_value

--- a/src/main/python/cfn_sphere/stack_configuration/__init__.py
+++ b/src/main/python/cfn_sphere/stack_configuration/__init__.py
@@ -138,18 +138,25 @@ class Config(object):
 
         service_id = metadata["id"]
         component_id = metadata.get('orgId', 'Scout24') + "/" + metadata["id"]
-        confidentiality = metadata.get('confidentiality', 'notinuse')
-        criticality = metadata.get('criticality', {}).get('value', 'notinuse')
         
         self.logger.info("Determined service-id to be %s" % service_id)
         self.logger.info("Determined component-id to be %s" % component_id)
 
-        return {
+        tags = {
             "service-id": service_id,
             "component-id": component_id,
-            "confidentiality": confidentiality,
-            "criticality": criticality,
         }
+        
+        # Only add confidentiality if it exists
+        if metadata.get('confidentiality'):
+            tags['confidentiality'] = metadata['confidentiality']
+        
+        # Only add criticality if it exists
+        criticality_value = metadata.get('criticality', {}).get('value')
+        if criticality_value:
+            tags['criticality'] = criticality_value
+
+        return tags
 
     def _find_metadata_file(self, basedir):
         f = None

--- a/src/main/python/cfn_sphere/stack_configuration/__init__.py
+++ b/src/main/python/cfn_sphere/stack_configuration/__init__.py
@@ -138,12 +138,17 @@ class Config(object):
 
         service_id = metadata["id"]
         component_id = metadata.get('orgId', 'Scout24') + "/" + metadata["id"]
+        confidentiality = metadata.get('confidentiality', 'notinuse')
+        criticality = metadata.get('criticality', {}).get('value', 'notinuse')
+        
         self.logger.info("Determined service-id to be %s" % service_id)
         self.logger.info("Determined component-id to be %s" % component_id)
 
         return {
             "service-id": service_id,
             "component-id": component_id,
+            "confidentiality": confidentiality,
+            "criticality": criticality,
         }
 
     def _find_metadata_file(self, basedir):

--- a/src/main/python/cfn_sphere/stack_configuration/__init__.py
+++ b/src/main/python/cfn_sphere/stack_configuration/__init__.py
@@ -132,26 +132,22 @@ class Config(object):
         loader = FileLoader()
         metadata = loader.get_yaml_or_json_file(file, working_dir=os.getcwd())
 
-        # If we don't even have ID, we can't go further
-        if not metadata.get('id'):
-            return {}
-
-        service_id = metadata["id"]
-        component_id = metadata.get('orgId', 'Scout24') + "/" + metadata["id"]
+        tags = {}
         
-        self.logger.info("Determined service-id to be %s" % service_id)
-        self.logger.info("Determined component-id to be %s" % component_id)
-
-        tags = {
-            "service-id": service_id,
-            "component-id": component_id,
-        }
+        # Only create service-id and component-id if id exists
+        if metadata.get('id'):
+            service_id = metadata["id"]
+            component_id = metadata.get('orgId', 'Scout24') + "/" + metadata["id"]
+            tags['service-id'] = service_id
+            tags['component-id'] = component_id
+            self.logger.info("Determined service-id to be %s" % service_id)
+            self.logger.info("Determined component-id to be %s" % component_id)
         
-        # Only add confidentiality if it exists
+        # Read confidentiality regardless of id
         if metadata.get('confidentiality'):
             tags['confidentiality'] = metadata['confidentiality']
         
-        # Only add criticality if it exists
+        # Read criticality regardless of id
         criticality_value = metadata.get('criticality', {}).get('value')
         if criticality_value:
             tags['criticality'] = criticality_value

--- a/src/main/python/cfn_sphere/util.py
+++ b/src/main/python/cfn_sphere/util.py
@@ -118,7 +118,7 @@ def convert_json_to_yaml_string(data):
 def convert_yaml_to_json_string(data):
     if not data:
         return '{}'
-    return json.dumps(yaml.load(data), indent=2)
+    return json.dumps(yaml.load(data, Loader=yaml.SafeLoader), indent=2)
 
 
 def convert_dict_to_json_string(data):

--- a/src/unittest/python/aws_tests/cfn_tests.py
+++ b/src/unittest/python/aws_tests/cfn_tests.py
@@ -1,5 +1,5 @@
 try:
-    from unittest2 import TestCase
+    from unittest import TestCase
     from mock import Mock, patch
 except ImportError:
     from unittest import TestCase

--- a/src/unittest/python/aws_tests/cfn_tests.py
+++ b/src/unittest/python/aws_tests/cfn_tests.py
@@ -243,7 +243,7 @@ class CloudFormationApiTests(TestCase):
         cfn.create_stack(stack)
 
         cloudformation_mock.return_value.create_stack.assert_called_once_with(
-            Capabilities=['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM'],
+            Capabilities=['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM', 'CAPABILITY_AUTO_EXPAND'],
             Parameters=[('a', 'b')],
             StackName='stack-name',
             Tags=[('any-tag', 'any-tag-value')],
@@ -272,7 +272,7 @@ class CloudFormationApiTests(TestCase):
         cfn.create_stack(stack)
 
         cloudformation_mock.return_value.create_stack.assert_called_once_with(
-            Capabilities=['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM'],
+            Capabilities=['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM', 'CAPABILITY_AUTO_EXPAND'],
             Parameters=[('a', 'b')],
             StackName='stack-name',
             Tags=[('any-tag', 'any-tag-value')],
@@ -302,7 +302,7 @@ class CloudFormationApiTests(TestCase):
         cfn.create_stack(stack)
 
         cloudformation_mock.return_value.create_stack.assert_called_once_with(
-            Capabilities=['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM'],
+            Capabilities=['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM', 'CAPABILITY_AUTO_EXPAND'],
             Parameters=[('a', 'b')],
             StackName='stack-name',
             Tags=[('any-tag', 'any-tag-value')],
@@ -332,7 +332,7 @@ class CloudFormationApiTests(TestCase):
         cfn.create_stack(stack)
 
         cloudformation_mock.return_value.create_stack.assert_called_once_with(
-            Capabilities=['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM'],
+            Capabilities=['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM', 'CAPABILITY_AUTO_EXPAND'],
             OnFailure='DO_NOTHING',
             Parameters=[('a', 'b')],
             StackName='stack-name',
@@ -363,7 +363,7 @@ class CloudFormationApiTests(TestCase):
         cfn.create_stack(stack)
 
         cloudformation_mock.return_value.create_stack.assert_called_once_with(
-            Capabilities=['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM'],
+            Capabilities=['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM', 'CAPABILITY_AUTO_EXPAND'],
             OnFailure='DO_NOTHING',
             DisableRollback=True,
             Parameters=[('a', 'b')],
@@ -412,7 +412,7 @@ class CloudFormationApiTests(TestCase):
         cfn.update_stack(stack)
 
         cloudformation_mock.return_value.update_stack.assert_called_once_with(
-            Capabilities=['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM'],
+            Capabilities=['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM', 'CAPABILITY_AUTO_EXPAND'],
             Parameters=[('a', 'b')],
             StackName='stack-name',
             Tags=[('any-tag', 'any-tag-value')],
@@ -438,7 +438,7 @@ class CloudFormationApiTests(TestCase):
         cfn.update_stack(stack)
 
         cloudformation_mock.return_value.update_stack.assert_called_once_with(
-            Capabilities=['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM'],
+            Capabilities=['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM', 'CAPABILITY_AUTO_EXPAND'],
             Parameters=[('a', 'b')],
             StackName='stack-name',
             Tags=[('any-tag', 'any-tag-value')],
@@ -465,7 +465,7 @@ class CloudFormationApiTests(TestCase):
         cfn.update_stack(stack)
 
         cloudformation_mock.return_value.update_stack.assert_called_once_with(
-            Capabilities=['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM'],
+            Capabilities=['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM', 'CAPABILITY_AUTO_EXPAND'],
             Parameters=[('a', 'b')],
             StackName='stack-name',
             Tags=[('any-tag', 'any-tag-value')],

--- a/src/unittest/python/aws_tests/ec2_tests.py
+++ b/src/unittest/python/aws_tests/ec2_tests.py
@@ -1,5 +1,5 @@
 try:
-    from unittest2 import TestCase
+    from unittest import TestCase
     from mock import Mock, patch
 except ImportError:
     from unittest import TestCase

--- a/src/unittest/python/aws_tests/kms_tests.py
+++ b/src/unittest/python/aws_tests/kms_tests.py
@@ -1,5 +1,5 @@
 try:
-    from unittest2 import TestCase
+    from unittest import TestCase
     from mock import patch
 except ImportError:
     from unittest import TestCase

--- a/src/unittest/python/aws_tests/s3_tests.py
+++ b/src/unittest/python/aws_tests/s3_tests.py
@@ -1,9 +1,9 @@
 from botocore.response import StreamingBody
-import unittest2
+import unittest
 
 
 try:
-    from unittest2 import TestCase
+    from unittest import TestCase
     from mock import Mock, patch
 except ImportError:
     from unittest import TestCase
@@ -12,7 +12,7 @@ except ImportError:
 from cfn_sphere.aws.s3 import S3
 
 
-class S3Tests(unittest2.TestCase):
+class S3Tests(unittest.TestCase):
     def test_parse_url_properly_parses_s3_url(self):
         (protocol, bucket_name, key_name) = S3._parse_url('s3://my-bucket/my/key/file.json')
         self.assertEqual('s3', protocol)

--- a/src/unittest/python/aws_tests/ssm_tests.py
+++ b/src/unittest/python/aws_tests/ssm_tests.py
@@ -1,5 +1,5 @@
 try:
-    from unittest2 import TestCase
+    from unittest import TestCase
     from mock import patch
 except ImportError:
     from unittest import TestCase

--- a/src/unittest/python/cli_tests.py
+++ b/src/unittest/python/cli_tests.py
@@ -2,7 +2,7 @@ from cfn_sphere.cli import get_first_account_alias_or_account_id
 from cfn_sphere.exceptions import CfnSphereException
 
 try:
-    from unittest2 import TestCase
+    from unittest import TestCase
     from mock import patch, Mock
 except ImportError:
     from unittest import TestCase

--- a/src/unittest/python/cloudformation_template_tests.py
+++ b/src/unittest/python/cloudformation_template_tests.py
@@ -1,5 +1,5 @@
 try:
-    from unittest2 import TestCase
+    from unittest import TestCase
 except ImportError:
     from unittest import TestCase
 

--- a/src/unittest/python/file_generator_tests.py
+++ b/src/unittest/python/file_generator_tests.py
@@ -1,4 +1,4 @@
-from unittest2 import TestCase
+from unittest import TestCase
 
 from cfn_sphere.exceptions import CfnSphereException
 from cfn_sphere.file_generator import FileGenerator

--- a/src/unittest/python/file_loader_tests.py
+++ b/src/unittest/python/file_loader_tests.py
@@ -69,7 +69,7 @@ class FileLoaderTests(TestCase):
         get_file_mock.return_value = get_file_return_value
 
         FileLoader.get_yaml_or_json_file('foo.json', 'baa')
-        json_mock.loads.assert_called_once_with(get_file_return_value, encoding="utf-8")
+        json_mock.loads.assert_called_once_with(get_file_return_value)
 
     @patch("cfn_sphere.file_loader.yaml")
     @patch("cfn_sphere.file_loader.FileLoader.get_file")

--- a/src/unittest/python/file_loader_tests.py
+++ b/src/unittest/python/file_loader_tests.py
@@ -1,7 +1,7 @@
 import yaml
 
 try:
-    from unittest2 import TestCase
+    from unittest import TestCase
     from mock import patch, Mock
 except ImportError:
     from unittest import TestCase

--- a/src/unittest/python/stack_action_handler_tests.py
+++ b/src/unittest/python/stack_action_handler_tests.py
@@ -1,5 +1,5 @@
 try:
-    from unittest2 import TestCase
+    from unittest import TestCase
     from mock import patch, Mock, call
 except ImportError:
     from unittest import TestCase

--- a/src/unittest/python/stack_configuration_tests/config_tests.py
+++ b/src/unittest/python/stack_configuration_tests/config_tests.py
@@ -1,7 +1,7 @@
 import os
 
 try:
-    from unittest2 import TestCase
+    from unittest import TestCase
 except ImportError:
     from unittest import TestCase
 

--- a/src/unittest/python/stack_configuration_tests/dependency_resolver_tests.py
+++ b/src/unittest/python/stack_configuration_tests/dependency_resolver_tests.py
@@ -1,5 +1,5 @@
 try:
-    from unittest2 import TestCase
+    from unittest import TestCase
 except ImportError:
     from unittest import TestCase
 

--- a/src/unittest/python/stack_configuration_tests/parameter_resolver_tests.py
+++ b/src/unittest/python/stack_configuration_tests/parameter_resolver_tests.py
@@ -1,5 +1,5 @@
 try:
-    from unittest2 import TestCase
+    from unittest import TestCase
     from mock import patch, Mock
 except ImportError:
     from unittest import TestCase

--- a/src/unittest/python/template/template_handler_tests.py
+++ b/src/unittest/python/template/template_handler_tests.py
@@ -4,7 +4,7 @@ from cfn_sphere import TemplateHandler
 from cfn_sphere.template import CloudFormationTemplate
 
 try:
-    from unittest2 import TestCase
+    from unittest import TestCase
     from mock import Mock
 except ImportError:
     from unittest import TestCase

--- a/src/unittest/python/template/template_tests.py
+++ b/src/unittest/python/template/template_tests.py
@@ -5,7 +5,7 @@ from six import string_types
 from cfn_sphere.template import CloudFormationTemplate
 
 try:
-    from unittest2 import TestCase
+    from unittest import TestCase
     from mock import Mock
 except ImportError:
     from unittest import TestCase

--- a/src/unittest/python/template/transformer_tests.py
+++ b/src/unittest/python/template/transformer_tests.py
@@ -1,7 +1,7 @@
 import json
 
 try:
-    from unittest2 import TestCase
+    from unittest import TestCase
     from mock import Mock
 except ImportError:
     from unittest import TestCase

--- a/src/unittest/python/util_tests.py
+++ b/src/unittest/python/util_tests.py
@@ -3,7 +3,7 @@ import tempfile
 from git import InvalidGitRepositoryError
 
 try:
-    from unittest2 import TestCase
+    from unittest import TestCase
     from mock import patch, Mock
 except ImportError:
     from unittest import TestCase

--- a/src/unittest/python/util_tests.py
+++ b/src/unittest/python/util_tests.py
@@ -26,8 +26,6 @@ class UtilTests(TestCase):
         foo:
           foo: baa
         """)
-
-        print(util.convert_yaml_to_json_string(data))
         self.assertEqual('{\n  "foo": {\n    "foo": "baa"\n  }\n}', util.convert_yaml_to_json_string(data))
 
     def test_convert_yaml_to_json_string_returns_valid_json_string_on_empty_string_input(self):


### PR DESCRIPTION
## Summary

- derive canonical component-id and compatibility service-id from repository identity instead of metadata id/orgId
- use GITHUB_REPOSITORY, Jenkins GIT_URL, or GitPython remote discovery without invoking Git
- normalize repository names and enforce derived IDs over default, CLI, and stack tags with warnings

## Verification

- `.venv/bin/pyb run_unit_tests` (268 tests)